### PR TITLE
[Feat] VideoDetail 페이지 UI 구현 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ function App() {
             <Header />
             <Routes>
                 <Route path="/" element={<Home />} />
-                <Route path="/video/:id" element={<VideoDetail />} />
+                <Route path="/video/:videoId" element={<VideoDetail />} />
             </Routes>
         </>
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,18 @@ import './App.css';
 
 import { Route, Routes } from 'react-router-dom';
 
+import Header from './components/Header/Header';
 import Home from './pages/Home';
+import VideoDetail from './pages/VideoDetail';
 
 function App() {
     return (
         <>
-            <Home />
+            <Header />
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/video/:id" element={<VideoDetail />} />
+            </Routes>
         </>
     );
 }

--- a/src/components/Header/HeaderLogo.jsx
+++ b/src/components/Header/HeaderLogo.jsx
@@ -1,8 +1,10 @@
+import { Link } from 'react-router-dom';
+
 const HeaderLogo = () => {
     return (
-        <a href="#" className="logo-padding p-">
+        <Link to="/" className="logo-padding">
             <img src="/yt-logo.svg" draggable="false" alt="로고"></img>
-        </a>
+        </Link>
     );
 };
 

--- a/src/components/Header/HeaderLogo.jsx
+++ b/src/components/Header/HeaderLogo.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 const HeaderLogo = () => {
     return (
-        <Link to="/" className="logo-padding">
+        <Link to="/" className="logo-padding flex-shrink-0">
             <img src="/yt-logo.svg" draggable="false" alt="로고"></img>
         </Link>
     );

--- a/src/components/Header/HeaderUserMenu.jsx
+++ b/src/components/Header/HeaderUserMenu.jsx
@@ -1,13 +1,23 @@
 import ThemeToggleButton from './ThemeToggleButton';
+import { useNavigate } from 'react-router-dom';
 import userProfile from '../../assets/user-profile.jpg';
 
 const HeaderUserMenu = () => {
+    const navigate = useNavigate();
+
+    const handleProfileClick = () => {
+        navigate('/mypage');
+    };
+
     return (
         <div className="flex items-center">
             <ThemeToggleButton />
 
             <div className="flex px-1">
-                <button className="mx-2 w-8 h-8 rounded-full overflow-hidden focus:shadow-[0_0_0_1px_#1c62b9]">
+                <button
+                    className="mx-2 w-8 h-8 rounded-full overflow-hidden focus:shadow-[0_0_0_1px_#1c62b9]"
+                    onClick={handleProfileClick}
+                >
                     <img
                         className="w-full h-full object-cover"
                         draggable="false"

--- a/src/components/SideBar/SideBarItem.jsx
+++ b/src/components/SideBar/SideBarItem.jsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const SideBarItem = ({ icon: Icon, href, alt, text }) => {
     const location = useLocation();
@@ -7,10 +7,10 @@ const SideBarItem = ({ icon: Icon, href, alt, text }) => {
 
     return (
         <div className="sidebar-item-container">
-            <a className={`sidebar-item ${isActive ? 'text-red-500' : ''}`} href={href}>
-                <Icon strokeWidth={1.5} alt={alt} />
+            <Link className={`sidebar-item ${isActive ? 'text-red-500' : ''}`} to={href} aria-label={alt}>
+                <Icon strokeWidth={1.5} />
                 <span className="sidebar-text">{text}</span>
-            </a>
+            </Link>
         </div>
     );
 };

--- a/src/components/VideoDetail/RecommendedVideos.jsx
+++ b/src/components/VideoDetail/RecommendedVideos.jsx
@@ -1,0 +1,18 @@
+import VideoCard from '../VideoGrid/VideoCard';
+
+const RecommendedVideos = ({ videos, onCardClick }) => {
+    return (
+        <div className="recommended-videos pt-6 pb-6 mr-6 w-[402px] min-w-[300px]">
+            {videos.slice(0, 10).map((video) => (
+                <VideoCard
+                    key={video.videoId}
+                    {...video}
+                    layout="horizontal"
+                    onClick={() => onCardClick(video.videoId)}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default RecommendedVideos;

--- a/src/components/VideoDetail/RecommendedVideos.jsx
+++ b/src/components/VideoDetail/RecommendedVideos.jsx
@@ -25,6 +25,9 @@ const RecommendedVideos = ({ videos, onCardClick }) => {
                             key={video.videoId}
                             {...video}
                             layout="vertical"
+                            showProfile={false}
+                            compact={true}
+                            isGridItem={true}
                             onClick={() => onCardClick(video.videoId)}
                         />
                     ))}

--- a/src/components/VideoDetail/RecommendedVideos.jsx
+++ b/src/components/VideoDetail/RecommendedVideos.jsx
@@ -3,7 +3,7 @@ import VideoCard from '../VideoGrid/VideoCard';
 const RecommendedVideos = ({ videos, onCardClick }) => {
     return (
         <div className="recommended-videos pt-6 pb-6 mr-6 w-[402px] min-w-[300px]">
-            {videos.slice(0, 10).map((video) => (
+            {videos.map((video) => (
                 <VideoCard
                     key={video.videoId}
                     {...video}

--- a/src/components/VideoDetail/RecommendedVideos.jsx
+++ b/src/components/VideoDetail/RecommendedVideos.jsx
@@ -1,16 +1,46 @@
+import { useEffect, useState } from 'react';
+
 import VideoCard from '../VideoGrid/VideoCard';
 
 const RecommendedVideos = ({ videos, onCardClick }) => {
+    const [isMobile, setIsMobile] = useState(false);
+
+    // 화면 너비 기준으로 horizontal ↔ vertical 전환
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth < 1024); // Tailwind의 lg 기준
+        };
+
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
     return (
-        <div className="recommended-videos pt-6 pb-6 mr-6 w-[402px] min-w-[300px]">
-            {videos.map((video) => (
-                <VideoCard
-                    key={video.videoId}
-                    {...video}
-                    layout="horizontal"
-                    onClick={() => onCardClick(video.videoId)}
-                />
-            ))}
+        <div className="recommended-videos">
+            {isMobile ? (
+                <div className="ml-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                    {videos.map((video) => (
+                        <VideoCard
+                            key={video.videoId}
+                            {...video}
+                            layout="vertical"
+                            onClick={() => onCardClick(video.videoId)}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {videos.map((video) => (
+                        <VideoCard
+                            key={video.videoId}
+                            {...video}
+                            layout="horizontal"
+                            onClick={() => onCardClick(video.videoId)}
+                        />
+                    ))}
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/VideoDetail/VideoDescription.jsx
+++ b/src/components/VideoDetail/VideoDescription.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+
+const VideoDescription = ({ views, uploadedAt, description }) => {
+    // description 영역이 펼쳐진 상태인지 저장
+    const [isExpanded, setIsExpanded] = useState(false);
+    // description 영역의 최대 높이
+    const [maxHeight, setMaxHeight] = useState('none');
+    // description 텍스트 div DOM 참조
+    const textRef = useRef(null);
+
+    // isExpanded 상태가 바뀔 때마다 maxHeight 계산
+    useEffect(() => {
+        if (!isExpanded && textRef.current) {
+            const lineHeight = parseFloat(getComputedStyle(textRef.current).lineHeight);
+            setMaxHeight(`${lineHeight * 2}px`); // 줄 높이 × 2줄
+        } else {
+            // 펼쳐진 상태면 제한 없이 전체 표시
+            setMaxHeight('none'); // 전체 보기
+        }
+    }, [isExpanded]);
+
+    return (
+        <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
+            <div className="p-3 relative">
+                {/* 조회수 및 업로드 날짜 표시 */}
+                <div className="font-medium">
+                    조회수 {views} {uploadedAt}
+                </div>
+
+                {/* description 텍스트 영역 */}
+                <div
+                    ref={textRef}
+                    className="w-full whitespace-pre-line overflow-hidden transition-all duration-200"
+                    style={{ maxHeight }}
+                >
+                    {description}
+                </div>
+
+                {/* 더보기/간략히 버튼 */}
+                <button
+                    onClick={() => setIsExpanded((prev) => !prev)}
+                    className="mt-2 font-medium rounded active:bg-black/20 transition-colors"
+                >
+                    {isExpanded ? '간략히' : '...더보기'}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default VideoDescription;

--- a/src/components/VideoDetail/VideoInfo.jsx
+++ b/src/components/VideoDetail/VideoInfo.jsx
@@ -5,12 +5,15 @@ const VideoInfo = ({ title, username, description }) => {
         <div className="mt-3 mb-6">
             <div className="video-title text-xl font-bold">{title}</div>
 
-            <div className="channel-info flex items-center w-fit mr-3 mt-3">
+            <div className="channel-info relative flex items-center w-fit mr-3 mt-3">
                 <div className="rounded-full overflow-hidden w-10 h-10 mr-4 cursor-pointer">
                     <img src={UserProfile} draggable="false" alt={`${username} 채널 사진`} />
                 </div>
 
-                <div className="flex items-center font-medium text-base cursor-pointer">{username}</div>
+                <div className="group">
+                    <div className="flex items-center font-medium text-base cursor-pointer">{username}</div>
+                    <div className="tooltip -top-16">{username}</div>
+                </div>
             </div>
 
             <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">

--- a/src/components/VideoDetail/VideoInfo.jsx
+++ b/src/components/VideoDetail/VideoInfo.jsx
@@ -1,0 +1,41 @@
+import UserProfile from '../../assets/user-profile.jpg';
+
+const VideoInfo = ({ title, username }) => {
+    return (
+        <div className="mt-3 mb-6">
+            <div className="video-title text-xl font-bold">{title}</div>
+
+            <div className="channel-info flex items-center w-fit mr-3 mt-3">
+                <div className="rounded-full overflow-hidden w-10 h-10 mr-4 cursor-pointer">
+                    <img src={UserProfile} draggable="false" alt={`${username} 채널 사진`} />
+                </div>
+
+                <div className="flex items-center font-medium text-base cursor-pointer">{username}</div>
+            </div>
+
+            <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
+                <div className="p-3">
+                    <div className="w-full">
+                        흘러가는대로 살고싶은 브금
+                        <br />
+                        오늘 할 일을 내일로 미루고
+                        <br />또 미루고
+                        <br />또 또 미루ㄱ....
+                        <br />
+                        <br />
+                        이번엔 왜..? ^-^
+                        <br />
+                        <br />. . .<br />
+                        <br />
+                        우하하
+                        <br />
+                        <br />
+                        배고프다 졸리다 자고싶다
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default VideoInfo;

--- a/src/components/VideoDetail/VideoInfo.jsx
+++ b/src/components/VideoDetail/VideoInfo.jsx
@@ -1,4 +1,5 @@
 import UserProfile from '../../assets/user-profile.jpg';
+import VideoDescription from './VideoDescription';
 
 const VideoInfo = ({ title, username, views, uploadedAt, description }) => {
     return (
@@ -16,14 +17,7 @@ const VideoInfo = ({ title, username, views, uploadedAt, description }) => {
                 </div>
             </div>
 
-            <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
-                <div className="p-3">
-                    <div className="font-medium">
-                        조회수 {views} {uploadedAt}
-                    </div>
-                    <div className="w-full whitespace-pre-line">{description}</div>
-                </div>
-            </div>
+            <VideoDescription views={views} uploadedAt={uploadedAt} description={description} />
         </div>
     );
 };

--- a/src/components/VideoDetail/VideoInfo.jsx
+++ b/src/components/VideoDetail/VideoInfo.jsx
@@ -1,6 +1,6 @@
 import UserProfile from '../../assets/user-profile.jpg';
 
-const VideoInfo = ({ title, username }) => {
+const VideoInfo = ({ title, username, description }) => {
     return (
         <div className="mt-3 mb-6">
             <div className="video-title text-xl font-bold">{title}</div>
@@ -15,23 +15,7 @@ const VideoInfo = ({ title, username }) => {
 
             <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
                 <div className="p-3">
-                    <div className="w-full">
-                        흘러가는대로 살고싶은 브금
-                        <br />
-                        오늘 할 일을 내일로 미루고
-                        <br />또 미루고
-                        <br />또 또 미루ㄱ....
-                        <br />
-                        <br />
-                        이번엔 왜..? ^-^
-                        <br />
-                        <br />. . .<br />
-                        <br />
-                        우하하
-                        <br />
-                        <br />
-                        배고프다 졸리다 자고싶다
-                    </div>
+                    <div className="w-full whitespace-pre-line">{description}</div>
                 </div>
             </div>
         </div>

--- a/src/components/VideoDetail/VideoInfo.jsx
+++ b/src/components/VideoDetail/VideoInfo.jsx
@@ -1,6 +1,6 @@
 import UserProfile from '../../assets/user-profile.jpg';
 
-const VideoInfo = ({ title, username, description }) => {
+const VideoInfo = ({ title, username, views, uploadedAt, description }) => {
     return (
         <div className="mt-3 mb-6">
             <div className="video-title text-xl font-bold">{title}</div>
@@ -18,6 +18,9 @@ const VideoInfo = ({ title, username, description }) => {
 
             <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
                 <div className="p-3">
+                    <div className="font-medium">
+                        조회수 {views} {uploadedAt}
+                    </div>
                     <div className="w-full whitespace-pre-line">{description}</div>
                 </div>
             </div>

--- a/src/components/VideoDetail/VideoPlayer.jsx
+++ b/src/components/VideoDetail/VideoPlayer.jsx
@@ -1,0 +1,15 @@
+const VideoPlayer = ({ videoSrc }) => {
+    return (
+        <div className="aspect-video bg-gray-200 rounded-lg overflow-hidden">
+            <iframe
+                className="w-full h-full"
+                src={videoSrc}
+                title="YouTube video player"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+            />
+        </div>
+    );
+};
+
+export default VideoPlayer;

--- a/src/components/VideoGrid/VideoCard.jsx
+++ b/src/components/VideoGrid/VideoCard.jsx
@@ -2,20 +2,24 @@ import VideoCardContent from './VideoCardContent';
 import VideoThumbnail from './VideoThumbnail';
 import { useNavigate } from 'react-router-dom';
 
-const VideoCard = ({ videoId, username, title, views, uploadedAt }) => {
+const VideoCard = ({ videoId, username, title, views, uploadedAt, layout = 'vertical' }) => {
     const navigate = useNavigate();
+    const isHorizontal = layout === 'horizontal';
 
     const handleCardClick = () => {
         navigate(`/video/${videoId}`);
     };
 
     return (
-        <div onClick={handleCardClick} className="relative cursor-pointer group/click">
+        <div
+            onClick={handleCardClick}
+            className={`relative cursor-pointer group/click ${isHorizontal ? 'flex gap-2 mt-2' : ''}`}
+        >
             {/* 썸네일 */}
-            <VideoThumbnail />
+            <VideoThumbnail layout={layout} />
 
             {/* 콘텐츠 하단 영역 */}
-            <VideoCardContent username={username} title={title} views={views} uploadedAt={uploadedAt} />
+            <VideoCardContent username={username} title={title} views={views} uploadedAt={uploadedAt} layout={layout} />
 
             {/* 클릭 효과 */}
             <div className="absolute inset-0 -m-1 pointer-events-none">

--- a/src/components/VideoGrid/VideoCard.jsx
+++ b/src/components/VideoGrid/VideoCard.jsx
@@ -2,7 +2,17 @@ import VideoCardContent from './VideoCardContent';
 import VideoThumbnail from './VideoThumbnail';
 import { useNavigate } from 'react-router-dom';
 
-const VideoCard = ({ videoId, username, title, views, uploadedAt, layout = 'vertical' }) => {
+const VideoCard = ({
+    videoId,
+    username,
+    title,
+    views,
+    uploadedAt,
+    layout = 'vertical',
+    showProfile = true,
+    compact = false,
+    isGridItem = false,
+}) => {
     const navigate = useNavigate();
     const isHorizontal = layout === 'horizontal';
 
@@ -19,7 +29,16 @@ const VideoCard = ({ videoId, username, title, views, uploadedAt, layout = 'vert
             <VideoThumbnail layout={layout} />
 
             {/* 콘텐츠 하단 영역 */}
-            <VideoCardContent username={username} title={title} views={views} uploadedAt={uploadedAt} layout={layout} />
+            <VideoCardContent
+                username={username}
+                title={title}
+                views={views}
+                uploadedAt={uploadedAt}
+                layout={layout}
+                showProfile={showProfile}
+                compact={compact}
+                isGridItem={isGridItem}
+            />
 
             {/* 클릭 효과 */}
             <div className="absolute inset-0 -m-1 pointer-events-none">

--- a/src/components/VideoGrid/VideoCard.jsx
+++ b/src/components/VideoGrid/VideoCard.jsx
@@ -1,6 +1,5 @@
-import { EllipsisVertical } from 'lucide-react';
-import UserProfile from '../../assets/user-profile.jpg';
-import VideoThumnail from '../../assets/video_thumbnail.avif';
+import VideoCardContent from './VideoCardContent';
+import VideoThumbnail from './VideoThumbnail';
 import { useNavigate } from 'react-router-dom';
 
 const VideoCard = ({ videoId, username, title, views, uploadedAt }) => {
@@ -13,52 +12,10 @@ const VideoCard = ({ videoId, username, title, views, uploadedAt }) => {
     return (
         <div onClick={handleCardClick} className="relative cursor-pointer group/click">
             {/* 썸네일 */}
-            <div>
-                <div className="h-full overflow-hidden rounded-xl">
-                    <img
-                        className="w-full h-full object-cover "
-                        src={VideoThumnail}
-                        draggable="false"
-                        alt="영상 썸네일 사진"
-                    />
-                </div>
-            </div>
+            <VideoThumbnail />
 
             {/* 콘텐츠 하단 영역 */}
-            <div className="relative flex">
-                {/* 프로필 이미지 (유저 페이지 이동) */}
-                <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
-                    <a href={`/@${username}`}>
-                        <img
-                            className="w-full h-full object-cover"
-                            src={UserProfile}
-                            draggable="false"
-                            alt="채널 프로필 사진"
-                        />
-                    </a>
-                </div>
-
-                {/* 텍스트 영역 */}
-                <div className="pr-10">
-                    <div className="mt-3 mb-1 text-base font-medium line-clamp-2 break-all">{title}</div>
-
-                    <a className="inline-flex group videocard-content-text" href={`/@${username}`}>
-                        <div className="hover:text-[#0f0f0f] line-clamp-2 break-all">{username}</div>
-                        <div className="tooltip left-13 top-1 z-10">{username}</div>
-                    </a>
-                    <div className="videocard-content-text">{`조회수 ${views} • ${uploadedAt}`}</div>
-                </div>
-
-                <button
-                    className="ripple-effect absolute right-0 top-1 w-10 h-10 flex items-center justify-center active:bg-[rgba(0,0,0,0.1)] rounded-full"
-                    type="button"
-                    onClick={(e) => {
-                        e.stopPropagation(); // handleCardClick 동작 막기
-                    }}
-                >
-                    <EllipsisVertical size={20} alt="더보기" />
-                </button>
-            </div>
+            <VideoCardContent username={username} title={title} views={views} uploadedAt={uploadedAt} />
 
             {/* 클릭 효과 */}
             <div className="absolute inset-0 -m-1 pointer-events-none">

--- a/src/components/VideoGrid/VideoCard.jsx
+++ b/src/components/VideoGrid/VideoCard.jsx
@@ -1,10 +1,13 @@
 import { EllipsisVertical } from 'lucide-react';
 import UserProfile from '../../assets/user-profile.jpg';
 import VideoThumnail from '../../assets/video_thumbnail.avif';
+import { useNavigate } from 'react-router-dom';
 
 const VideoCard = ({ videoId, username, title, views, uploadedAt }) => {
+    const navigate = useNavigate();
+
     const handleCardClick = () => {
-        window.location.href = `/video/${videoId}`;
+        navigate(`/video/${videoId}`);
     };
 
     return (

--- a/src/components/VideoGrid/VideoCardContent.jsx
+++ b/src/components/VideoGrid/VideoCardContent.jsx
@@ -1,13 +1,22 @@
 import { EllipsisVertical } from 'lucide-react';
 import UserProfile from '../../assets/user-profile.jpg';
 
-const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertical' }) => {
+const VideoCardContent = ({
+    username,
+    title,
+    views,
+    uploadedAt,
+    layout = 'vertical',
+    showProfile = true,
+    compact = false,
+    isGridItem = false,
+}) => {
     const isHorizontal = layout === 'horizontal';
 
     return (
         <div className="relative flex w-full">
             {/* 프로필 이미지 (세로형 레이아웃일 때만 표시) */}
-            {!isHorizontal && (
+            {!isHorizontal && showProfile && (
                 <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
                     <img
                         className="w-full h-full object-cover"
@@ -19,11 +28,15 @@ const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertic
             )}
 
             {/* 텍스트 영역 */}
-            <div className={`${isHorizontal ? 'flex flex-col pr-6 pt-1' : 'pr-10'} `}>
+            <div
+                className={`${isHorizontal || compact ? 'flex flex-col pr-6' : 'pr-10'} ${
+                    isGridItem ? 'py-2' : 'pt-1'
+                }`}
+            >
                 {/* 영상 제목 */}
                 <div
                     className={`text-base font-medium line-clamp-2 break-all ${
-                        !isHorizontal ? 'mt-3 mb-1' : 'mb-1 text-sm'
+                        isHorizontal || compact ? 'mb-1 text-sm' : 'mt-3 mb-1'
                     }`}
                 >
                     {title}
@@ -32,7 +45,7 @@ const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertic
                 {/* 업로더 이름 + 툴팁 */}
                 <div
                     className={`${
-                        isHorizontal ? 'text-xs text-[#606060]' : 'inline-flex group videocard-content-text'
+                        isHorizontal || compact ? 'text-xs text-[#606060]' : 'inline-flex group videocard-content-text'
                     }`}
                 >
                     <div className="hover:text-[#0f0f0f] line-clamp-2 break-all">{username}</div>
@@ -41,15 +54,17 @@ const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertic
 
                 {/* 조회수 + 업로드 날짜 */}
                 <div
-                    className={`${isHorizontal ? 'text-xs text-[#606060]' : 'videocard-content-text'}`}
+                    className={`${isHorizontal || compact ? 'text-xs text-[#606060]' : 'videocard-content-text'}`}
                 >{`조회수 ${views} • ${uploadedAt}`}</div>
             </div>
 
             {/* 더보기 버튼 */}
             <button
                 className={`ripple-effect ${
-                    isHorizontal ? 'absolute right-0 w-6 h-6' : 'absolute right-0 top-1 w-10 h-10'
-                } active:bg-[rgba(0,0,0,0.1)] rounded-full flex items-center justify-center`}
+                    isHorizontal || compact ? 'absolute right-0 w-6 h-6' : 'absolute right-0 top-1 w-10 h-10'
+                }
+                ${isGridItem ? 'mt-2' : ''}
+                active:bg-[rgba(0,0,0,0.1)] rounded-full flex items-center justify-center`}
                 type="button"
                 onClick={(e) => e.stopPropagation()} // 상위 요소 클릭 이벤트 막기
             >

--- a/src/components/VideoGrid/VideoCardContent.jsx
+++ b/src/components/VideoGrid/VideoCardContent.jsx
@@ -1,0 +1,46 @@
+import { EllipsisVertical } from 'lucide-react';
+import UserProfile from '../../assets/user-profile.jpg';
+import { useNavigate } from 'react-router-dom';
+
+const VideoCardContent = ({ username, title, views, uploadedAt }) => {
+    const navigate = useNavigate();
+
+    return (
+        <div className="relative flex">
+            {/* 프로필 이미지 */}
+            <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
+                <a href={`/@${username}`}>
+                    <img
+                        className="w-full h-full object-cover"
+                        src={UserProfile}
+                        draggable="false"
+                        alt="채널 프로필 사진"
+                    />
+                </a>
+            </div>
+
+            {/* 텍스트 영역 */}
+            <div className="pr-10">
+                <div className="mt-3 mb-1 text-base font-medium line-clamp-2 break-all">{title}</div>
+
+                <a className="inline-flex group videocard-content-text" href={`/@${username}`}>
+                    <div className="hover:text-[#0f0f0f] line-clamp-2 break-all">{username}</div>
+                    <div className="tooltip left-13 top-1 z-10">{username}</div>
+                </a>
+
+                <div className="videocard-content-text">{`조회수 ${views} • ${uploadedAt}`}</div>
+            </div>
+
+            {/* 더보기 버튼 */}
+            <button
+                className="ripple-effect absolute right-0 top-1 w-10 h-10 flex items-center justify-center active:bg-[rgba(0,0,0,0.1)] rounded-full"
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <EllipsisVertical size={20} alt="더보기" />
+            </button>
+        </div>
+    );
+};
+
+export default VideoCardContent;

--- a/src/components/VideoGrid/VideoCardContent.jsx
+++ b/src/components/VideoGrid/VideoCardContent.jsx
@@ -5,7 +5,7 @@ const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertic
     const isHorizontal = layout === 'horizontal';
 
     return (
-        <div className="relative flex">
+        <div className="relative flex w-full">
             {/* 프로필 이미지 (세로형 레이아웃일 때만 표시) */}
             {!isHorizontal && (
                 <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
@@ -48,7 +48,7 @@ const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertic
             {/* 더보기 버튼 */}
             <button
                 className={`ripple-effect ${
-                    isHorizontal ? 'absolute -right-5 w-6 h-6' : 'absolute right-0 top-1 w-10 h-10'
+                    isHorizontal ? 'absolute right-0 w-6 h-6' : 'absolute right-0 top-1 w-10 h-10'
                 } active:bg-[rgba(0,0,0,0.1)] rounded-full flex items-center justify-center`}
                 type="button"
                 onClick={(e) => e.stopPropagation()} // 상위 요소 클릭 이벤트 막기

--- a/src/components/VideoGrid/VideoCardContent.jsx
+++ b/src/components/VideoGrid/VideoCardContent.jsx
@@ -1,41 +1,57 @@
 import { EllipsisVertical } from 'lucide-react';
 import UserProfile from '../../assets/user-profile.jpg';
-import { useNavigate } from 'react-router-dom';
 
-const VideoCardContent = ({ username, title, views, uploadedAt }) => {
-    const navigate = useNavigate();
+const VideoCardContent = ({ username, title, views, uploadedAt, layout = 'vertical' }) => {
+    const isHorizontal = layout === 'horizontal';
 
     return (
         <div className="relative flex">
-            {/* 프로필 이미지 */}
-            <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
-                <a href={`/@${username}`}>
+            {/* 프로필 이미지 (세로형 레이아웃일 때만 표시) */}
+            {!isHorizontal && (
+                <div className="mt-3 mr-3 overflow-hidden rounded-full w-9 h-9 flex-shrink-0">
                     <img
                         className="w-full h-full object-cover"
                         src={UserProfile}
                         draggable="false"
                         alt="채널 프로필 사진"
                     />
-                </a>
-            </div>
+                </div>
+            )}
 
             {/* 텍스트 영역 */}
-            <div className="pr-10">
-                <div className="mt-3 mb-1 text-base font-medium line-clamp-2 break-all">{title}</div>
+            <div className={`${isHorizontal ? 'flex flex-col pr-6 pt-1' : 'pr-10'} `}>
+                {/* 영상 제목 */}
+                <div
+                    className={`text-base font-medium line-clamp-2 break-all ${
+                        !isHorizontal ? 'mt-3 mb-1' : 'mb-1 text-sm'
+                    }`}
+                >
+                    {title}
+                </div>
 
-                <a className="inline-flex group videocard-content-text" href={`/@${username}`}>
+                {/* 업로더 이름 + 툴팁 */}
+                <div
+                    className={`${
+                        isHorizontal ? 'text-xs text-[#606060]' : 'inline-flex group videocard-content-text'
+                    }`}
+                >
                     <div className="hover:text-[#0f0f0f] line-clamp-2 break-all">{username}</div>
                     <div className="tooltip left-13 top-1 z-10">{username}</div>
-                </a>
+                </div>
 
-                <div className="videocard-content-text">{`조회수 ${views} • ${uploadedAt}`}</div>
+                {/* 조회수 + 업로드 날짜 */}
+                <div
+                    className={`${isHorizontal ? 'text-xs text-[#606060]' : 'videocard-content-text'}`}
+                >{`조회수 ${views} • ${uploadedAt}`}</div>
             </div>
 
             {/* 더보기 버튼 */}
             <button
-                className="ripple-effect absolute right-0 top-1 w-10 h-10 flex items-center justify-center active:bg-[rgba(0,0,0,0.1)] rounded-full"
+                className={`ripple-effect ${
+                    isHorizontal ? 'absolute -right-5 w-6 h-6' : 'absolute right-0 top-1 w-10 h-10'
+                } active:bg-[rgba(0,0,0,0.1)] rounded-full flex items-center justify-center`}
                 type="button"
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()} // 상위 요소 클릭 이벤트 막기
             >
                 <EllipsisVertical size={20} alt="더보기" />
             </button>

--- a/src/components/VideoGrid/VideoCardContent.jsx
+++ b/src/components/VideoGrid/VideoCardContent.jsx
@@ -28,11 +28,7 @@ const VideoCardContent = ({
             )}
 
             {/* 텍스트 영역 */}
-            <div
-                className={`${isHorizontal || compact ? 'flex flex-col pr-6' : 'pr-10'} ${
-                    isGridItem ? 'py-2' : 'pt-1'
-                }`}
-            >
+            <div className={`${isHorizontal || compact ? 'flex flex-col pr-6' : 'pr-10'} ${isGridItem ? 'py-2' : ''}`}>
                 {/* 영상 제목 */}
                 <div
                     className={`text-base font-medium line-clamp-2 break-all ${
@@ -44,12 +40,12 @@ const VideoCardContent = ({
 
                 {/* 업로더 이름 + 툴팁 */}
                 <div
-                    className={`${
-                        isHorizontal || compact ? 'text-xs text-[#606060]' : 'inline-flex group videocard-content-text'
+                    className={`group ${
+                        isHorizontal || compact ? 'text-xs text-[#606060]' : 'inline-flex videocard-content-text'
                     }`}
                 >
                     <div className="hover:text-[#0f0f0f] line-clamp-2 break-all">{username}</div>
-                    <div className="tooltip left-13 top-1 z-10">{username}</div>
+                    <div className="tooltip -top-5 z-10">{username}</div>
                 </div>
 
                 {/* 조회수 + 업로드 날짜 */}

--- a/src/components/VideoGrid/VideoGrid.jsx
+++ b/src/components/VideoGrid/VideoGrid.jsx
@@ -1,13 +1,5 @@
 import VideoCard from './VideoCard';
-
-// 임시 데이터
-const mockVideoData = Array.from({ length: 15 }, (_, i) => ({
-    videoId: i + 1,
-    username: `동숲거주자${i + 1}`,
-    title: `흘러가는대로 살고싶은 브금 #${i + 1}`,
-    views: `${(Math.random() * 100).toFixed(0)}만회`,
-    uploadedAt: `${Math.floor(Math.random() * 12) + 1}개월 전`,
-}));
+import mockVideoData from '../../data/mockVideoData';
 
 const VideoGrid = () => {
     return (

--- a/src/components/VideoGrid/VideoThumbnail.jsx
+++ b/src/components/VideoGrid/VideoThumbnail.jsx
@@ -1,9 +1,13 @@
 import VideoThumbnailImg from '../../assets/video_thumbnail.avif';
 
-const VideoThumbnail = () => {
+const VideoThumbnail = ({ layout = 'vertical' }) => {
     return (
         <div>
-            <div className="h-full overflow-hidden rounded-xl">
+            <div
+                className={`overflow-hidden rounded-xl bg-gray-200 ${
+                    layout === 'horizontal' ? 'w-[168px] h-[94px] flex-shrink-0' : 'w-full'
+                }`}
+            >
                 <img
                     className="w-full h-full object-cover"
                     src={VideoThumbnailImg}

--- a/src/components/VideoGrid/VideoThumbnail.jsx
+++ b/src/components/VideoGrid/VideoThumbnail.jsx
@@ -1,0 +1,18 @@
+import VideoThumbnailImg from '../../assets/video_thumbnail.avif';
+
+const VideoThumbnail = () => {
+    return (
+        <div>
+            <div className="h-full overflow-hidden rounded-xl">
+                <img
+                    className="w-full h-full object-cover"
+                    src={VideoThumbnailImg}
+                    draggable="false"
+                    alt="영상 썸네일 사진"
+                />
+            </div>
+        </div>
+    );
+};
+
+export default VideoThumbnail;

--- a/src/data/mockVideoData.js
+++ b/src/data/mockVideoData.js
@@ -1,0 +1,9 @@
+const mockVideoData = Array.from({ length: 15 }, (_, i) => ({
+    videoId: i + 1,
+    username: `동숲거주자${i + 1}`,
+    title: `흘러가는대로 살고싶은 브금 #${i + 1}`,
+    views: `${(Math.random() * 100).toFixed(0)}만회`,
+    uploadedAt: `${Math.floor(Math.random() * 12) + 1}개월 전`,
+}));
+
+export default mockVideoData;

--- a/src/data/mockVideoData.js
+++ b/src/data/mockVideoData.js
@@ -4,6 +4,9 @@ const mockVideoData = Array.from({ length: 15 }, (_, i) => ({
     title: `흘러가는대로 살고싶은 브금 #${i + 1}`,
     views: `${(Math.random() * 100).toFixed(0)}만회`,
     uploadedAt: `${Math.floor(Math.random() * 12) + 1}개월 전`,
+    description: `흘러가는대로 살고싶은 브금 #${
+        i + 1
+    }\n\n.\n\n.\n\n.\n\n너무너무 졸려 자고싶어\n\n.\n\n.\n\n.\n\n그치만 해야 해\n\n.\n\n.\n\n.\n\n😢😢`,
 }));
 
 export default mockVideoData;

--- a/src/data/mockVideoData.js
+++ b/src/data/mockVideoData.js
@@ -1,7 +1,7 @@
 const mockVideoData = Array.from({ length: 15 }, (_, i) => ({
     videoId: i + 1,
     username: `동숲거주자${i + 1}`,
-    title: `흘러는대로 살고싶은 브금 #${i + 1}`,
+    title: `흘러가는대로 살고싶은 브금 #${i + 1}`,
     views: `${(Math.random() * 100).toFixed(0)}만회`,
     uploadedAt: `${Math.floor(Math.random() * 12) + 1}개월 전`,
     description: `흘러가는대로 살고싶은 브금 #${

--- a/src/data/mockVideoData.js
+++ b/src/data/mockVideoData.js
@@ -1,7 +1,7 @@
 const mockVideoData = Array.from({ length: 15 }, (_, i) => ({
     videoId: i + 1,
     username: `동숲거주자${i + 1}`,
-    title: `흘러가는대로 살고싶은 브금 #${i + 1}`,
+    title: `흘러는대로 살고싶은 브금 #${i + 1}`,
     views: `${(Math.random() * 100).toFixed(0)}만회`,
     uploadedAt: `${Math.floor(Math.random() * 12) + 1}개월 전`,
     description: `흘러가는대로 살고싶은 브금 #${

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import VideoGrid from '../components/VideoGrid/VideoGrid';
 const Home = () => {
     return (
         <>
-            <div style={{ display: 'flex' }}>
+            <div className="flex">
                 <SideBar />
                 <VideoGrid />
             </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,9 @@
-import Header from '../components/Header/Header';
 import SideBar from '../components/SideBar/SideBar';
 import VideoGrid from '../components/VideoGrid/VideoGrid';
 
 const Home = () => {
     return (
         <>
-            <Header />
             <div style={{ display: 'flex' }}>
                 <SideBar />
                 <VideoGrid />

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -21,7 +21,13 @@ const VideoDetail = () => {
                 {/* 영상 */}
                 <VideoPlayer videoSrc="https://www.youtube.com/embed/0D-dHRtyiyE" />
                 {/* 영상 제목, 채널 사진 및 이름, 영상 description */}
-                <VideoInfo title={video.title} username={video.username} description={video.description} />
+                <VideoInfo
+                    title={video.title}
+                    username={video.username}
+                    views={video.views}
+                    uploadedAt={video.uploadedAt}
+                    description={video.description}
+                />
             </div>
 
             {/* 추천 영상 */}

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -1,11 +1,23 @@
-import { Link, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import UserProfile from '../assets/user-profile.jpg';
+import VideoCard from '../components/VideoGrid/VideoCard';
+import mockVideoData from '../data/mockVideoData';
 
 const VideoDetail = () => {
+    const navigate = useNavigate();
+    const { videoId } = useParams();
+
+    const video = mockVideoData.find((v) => v.videoId === Number(videoId));
+
+    const handleCardClick = (videoId) => {
+        navigate(`/video/${videoId}`);
+    };
+
     return (
         <>
             <div className="flex mt-14">
+                {/* 영상 */}
                 <div className="pt-6 ml-6 pr-6 flex-1">
                     <div className="aspect-video bg-gray-200 rounded-lg overflow-hidden">
                         <iframe
@@ -18,18 +30,16 @@ const VideoDetail = () => {
                     </div>
 
                     <div className="mt-3 mb-6">
-                        <div className="video-title text-xl font-bold">흘러가는대로 살고싶은 브금</div>
+                        <div className="video-title text-xl font-bold">{video.title}</div>
 
                         <div className="channel-info flex items-center w-fit mr-3 mt-3">
-                            <Link to={'/@username'}>
-                                <div className="rounded-full overflow-hidden w-10 h-10 mr-4">
-                                    <img src={UserProfile} draggable="false" alt="채널 사진" />
-                                </div>
-                            </Link>
+                            <div className="rounded-full overflow-hidden w-10 h-10 mr-4 cursor-pointer">
+                                <img src={UserProfile} draggable="false" alt={`${video.username} 채널 사진`} />
+                            </div>
 
-                            <Link to={'/@username'}>
-                                <div className="flex items-center font-medium text-base">동숲주민</div>
-                            </Link>
+                            <div className="flex items-center font-medium text-base cursor-pointer">
+                                {video.username}
+                            </div>
                         </div>
 
                         <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
@@ -56,7 +66,17 @@ const VideoDetail = () => {
                     </div>
                 </div>
 
-                <div className="pt-6 pr-6 w-[402px] min-w-[300px]">추천 영상</div>
+                {/* 추천 영상 */}
+                <div className="recommended-videos pt-6 pb-6 mr-6 w-[402px] min-w-[300px]">
+                    {mockVideoData.slice(0, 10).map((item) => (
+                        <VideoCard
+                            key={item.videoId}
+                            {...item}
+                            layout="horizontal"
+                            onClick={() => handleCardClick(item.videoId)}
+                        />
+                    ))}
+                </div>
             </div>
         </>
     );

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -1,7 +1,18 @@
 import { useParams } from 'react-router-dom';
 
 const VideoDetail = () => {
-    return <></>;
+    return (
+        <>
+            <div className="flex mt-14">
+                <div className="pt-6 ml-6 pr-6 flex-1">
+                    <div>영상</div>
+                    <div>영상 정보</div>
+                </div>
+
+                <div className="pt-6 pr-6 w-[402px] min-w-[300px]">추천 영상</div>
+            </div>
+        </>
+    );
 };
 
 export default VideoDetail;

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -21,7 +21,7 @@ const VideoDetail = () => {
                 {/* 영상 */}
                 <VideoPlayer videoSrc="https://www.youtube.com/embed/0D-dHRtyiyE" />
                 {/* 영상 제목, 채널 사진 및 이름, 영상 description */}
-                <VideoInfo title={video.title} username={video.username} />
+                <VideoInfo title={video.title} username={video.username} description={video.description} />
             </div>
 
             {/* 추천 영상 */}

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -1,4 +1,6 @@
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+
+import UserProfile from '../assets/user-profile.jpg';
 
 const VideoDetail = () => {
     return (
@@ -14,7 +16,24 @@ const VideoDetail = () => {
                             allowFullScreen
                         ></iframe>
                     </div>
-                    <div>영상 정보</div>
+
+                    <div className="mt-3 mb-6">
+                        <div className="video-title text-xl font-bold">흘러가는대로 살고싶은 브금</div>
+
+                        <div className="channel-info flex items-center w-fit mr-3 mt-3">
+                            <Link to={'/@username'}>
+                                <div className="rounded-full overflow-hidden w-10 h-10 mr-4">
+                                    <img src={UserProfile} draggable="false" alt="채널 사진" />
+                                </div>
+                            </Link>
+
+                            <Link to={'/@username'}>
+                                <div className="flex items-center font-medium text-base">동숲주민</div>
+                            </Link>
+                        </div>
+
+                        <div className="video-description">description</div>
+                    </div>
                 </div>
 
                 <div className="pt-6 pr-6 w-[402px] min-w-[300px]">추천 영상</div>

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -1,7 +1,8 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
-import UserProfile from '../assets/user-profile.jpg';
-import VideoCard from '../components/VideoGrid/VideoCard';
+import RecommendedVideos from '../components/VideoDetail/RecommendedVideos';
+import VideoInfo from '../components/VideoDetail/VideoInfo';
+import VideoPlayer from '../components/VideoDetail/VideoPlayer';
 import mockVideoData from '../data/mockVideoData';
 
 const VideoDetail = () => {
@@ -15,70 +16,17 @@ const VideoDetail = () => {
     };
 
     return (
-        <>
-            <div className="flex mt-14">
+        <div className="flex mt-14">
+            <div className="pt-6 ml-6 pr-6 flex-1">
                 {/* 영상 */}
-                <div className="pt-6 ml-6 pr-6 flex-1">
-                    <div className="aspect-video bg-gray-200 rounded-lg overflow-hidden">
-                        <iframe
-                            className="w-full h-full"
-                            src={`https://www.youtube.com/embed/0D-dHRtyiyE`}
-                            title="YouTube video player"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                            allowFullScreen
-                        ></iframe>
-                    </div>
-
-                    <div className="mt-3 mb-6">
-                        <div className="video-title text-xl font-bold">{video.title}</div>
-
-                        <div className="channel-info flex items-center w-fit mr-3 mt-3">
-                            <div className="rounded-full overflow-hidden w-10 h-10 mr-4 cursor-pointer">
-                                <img src={UserProfile} draggable="false" alt={`${video.username} 채널 사진`} />
-                            </div>
-
-                            <div className="flex items-center font-medium text-base cursor-pointer">
-                                {video.username}
-                            </div>
-                        </div>
-
-                        <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
-                            <div className="p-3">
-                                <div className="w-full">
-                                    흘러가는대로 살고싶은 브금
-                                    <br />
-                                    오늘 할 일을 내일로 미루고
-                                    <br />또 미루고
-                                    <br />또 또 미루ㄱ....
-                                    <br />
-                                    <br />
-                                    이번엔 왜..? ^-^
-                                    <br />
-                                    <br />. . .<br />
-                                    <br />
-                                    우하하
-                                    <br />
-                                    <br />
-                                    배고프다 졸리다 자고싶다
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* 추천 영상 */}
-                <div className="recommended-videos pt-6 pb-6 mr-6 w-[402px] min-w-[300px]">
-                    {mockVideoData.slice(0, 10).map((item) => (
-                        <VideoCard
-                            key={item.videoId}
-                            {...item}
-                            layout="horizontal"
-                            onClick={() => handleCardClick(item.videoId)}
-                        />
-                    ))}
-                </div>
+                <VideoPlayer videoSrc="https://www.youtube.com/embed/0D-dHRtyiyE" />
+                {/* 영상 제목, 채널 사진 및 이름, 영상 description */}
+                <VideoInfo title={video.title} username={video.username} />
             </div>
-        </>
+
+            {/* 추천 영상 */}
+            <RecommendedVideos videos={mockVideoData} onCardClick={handleCardClick} />
+        </div>
     );
 };
 

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -32,7 +32,27 @@ const VideoDetail = () => {
                             </Link>
                         </div>
 
-                        <div className="video-description">description</div>
+                        <div className="video-description mt-3 bg-[rgba(0,0,0,0.05)] rounded-xl text-sm font-normal cursor-pointer">
+                            <div className="p-3">
+                                <div className="w-full">
+                                    흘러가는대로 살고싶은 브금
+                                    <br />
+                                    오늘 할 일을 내일로 미루고
+                                    <br />또 미루고
+                                    <br />또 또 미루ㄱ....
+                                    <br />
+                                    <br />
+                                    이번엔 왜..? ^-^
+                                    <br />
+                                    <br />. . .<br />
+                                    <br />
+                                    우하하
+                                    <br />
+                                    <br />
+                                    배고프다 졸리다 자고싶다
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -5,7 +5,15 @@ const VideoDetail = () => {
         <>
             <div className="flex mt-14">
                 <div className="pt-6 ml-6 pr-6 flex-1">
-                    <div>영상</div>
+                    <div className="aspect-video bg-gray-200 rounded-lg overflow-hidden">
+                        <iframe
+                            className="w-full h-full"
+                            src={`https://www.youtube.com/embed/0D-dHRtyiyE`}
+                            title="YouTube video player"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowFullScreen
+                        ></iframe>
+                    </div>
                     <div>영상 정보</div>
                 </div>
 

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -16,7 +16,7 @@ const VideoDetail = () => {
     };
 
     return (
-        <div className="flex mt-14">
+        <div className="flex flex-col lg:flex-row mt-14">
             <div className="pt-6 ml-6 pr-6 flex-1">
                 {/* 영상 */}
                 <VideoPlayer videoSrc="https://www.youtube.com/embed/0D-dHRtyiyE" />
@@ -25,7 +25,9 @@ const VideoDetail = () => {
             </div>
 
             {/* 추천 영상 */}
-            <RecommendedVideos videos={mockVideoData} onCardClick={handleCardClick} />
+            <div className="w-full lg:w-[402px] lg:min-w-[300px] py-6 pr-6">
+                <RecommendedVideos videos={mockVideoData} onCardClick={handleCardClick} />
+            </div>
         </div>
     );
 };

--- a/src/pages/VideoDetail.jsx
+++ b/src/pages/VideoDetail.jsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+const VideoDetail = () => {
+    return <></>;
+};
+
+export default VideoDetail;


### PR DESCRIPTION
### ✅ 구현 사항
### 💡 VideoDetail 페이지 구성
### 📌 VideoPlayer
- `videoSrc`를 props로 받아 `<iframe>`으로 유튜브 영상 렌더링

### 📌 VideoInfo
- `title`, `username`, `views`, `uploadedAt`, `description`을 props로 받아 표시
- `username`에 마우스 `hover` 시 툴팁 표시

### 📌 VideoDescription
- `views`, `uploadedAt`, `description`을 props로 받아 상세 정보 렌더링
- `description` 이 길 경우 2줄까지만 보이고, **더보기** 버튼 클릭 시 전체 표시
- **간략히** 버튼 클릭 시 다시 2줄로 접힘

### 📌 RecommendedVideos
- 화면 크기에 따라 추천 영상 레이아웃 **반응형** 적용 (`VideoCard` 재사용)
  - `lg` 이상: 오른쪽에 `horizontal` 카드 리스트
  - `lg` 미만: 아래쪽에 `vertical` 카드 `grid` (3→2→1)

### ✨ 기타 변경 사항
 - 헤더 로고에 `flex-shrink-0` 적용 → 화면 축소 시 크기 유지
 - 임시 데이터 파일(`mockVideoData`) 분리하여 관리
 - `<a>` 태그를 `Link`와 `useNavigate`로 변경하여 SPA 라우팅 처리